### PR TITLE
fix sha2 bug

### DIFF
--- a/lua-aws/deps/sha2.lua
+++ b/lua-aws/deps/sha2.lua
@@ -65,7 +65,10 @@ end
 -- append length of message (before pre-processing), in bits, as 64-bit
 -- big-endian integer
 local function preproc (msg, len)
-  local extra = 64 - ((len + 1 + 8) % 64)
+  local extra = 56 - ((len + 1) % 64)
+  if extra < 0 then
+    extra = 64 + extra
+  end
   len = num2s(8 * len, 8)    -- original len in bits, coded
   msg = msg .. "\128" .. string.rep("\0", extra) .. len
   assert(#msg % 64 == 0)
@@ -152,7 +155,18 @@ local function digestblock (msg, i, H)
     H[6] = band(H[6] + f)
     H[7] = band(H[7] + g)
     H[8] = band(H[8] + h)
-
+    --[[
+    print("current digest:",
+      str2hexa(num2s(H[1], 4)),
+      str2hexa(num2s(H[2], 4)),
+      str2hexa(num2s(H[3], 4)),
+      str2hexa(num2s(H[4], 4)),
+      str2hexa(num2s(H[5], 4)),
+      str2hexa(num2s(H[6], 4)),
+      str2hexa(num2s(H[7], 4)),
+      str2hexa(num2s(H[8], 4))
+    )
+    ]]
 end
 
 

--- a/lua-aws/util.lua
+++ b/lua-aws/util.lua
@@ -200,11 +200,15 @@ _M.hmac = (function ()
 		local text = sha2.hash256(data)
 		return _M.to_bin(text)
 	end
-	local hmac_sha256 = function (key, data)
+	local digest_routines = {
+		hex = _M.to_hex,
+		base64 = _M.b64.encode
+	}
+	local hmac_sha256 = function (key, data, digest)
 		local bin = hmac(key, data, sha256, 64)
 		--	print(_M.to_hex(bin))
 		--local bin = _M.to_bin("8BDD6729CE0F580B7424921D5F0CFD1F1642243762CBA71FFCC8FABCFC72608B")
-		return _M.b64.encode(bin)
+		return digest_routines[digest](bin)
 	end
 
 	-- here simple test from http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-query-api.html#query-authentication
@@ -214,8 +218,9 @@ elasticmapreduce.amazonaws.com
 /
 AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Action=DescribeJobFlows&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2011-10-03T15%3A19%3A30&Version=2009-03-31]]
 
-	local test_enc = hmac_sha256(test_key, test)
+	local test_enc = hmac_sha256(test_key, test, 'base64')
 	assert(test_enc == 'i91nKc4PWAt0JJIdXwz9HxZCJDdiy6cf/Mj6vPxyYIs=')
+	--]]
 	return hmac_sha256
 end)()
 

--- a/test/deps/sha2.js
+++ b/test/deps/sha2.js
@@ -1,0 +1,143 @@
+/**
+*
+*  Secure Hash Algorithm (SHA256)
+*  http://www.webtoolkit.info/
+*
+*  Original code by Angel Marin, Paul Johnston.
+*
+**/
+ 
+function SHA256(s){
+ 
+	var chrsz   = 8;
+	var hexcase = 0;
+ 
+	function safe_add (x, y) {
+		var lsw = (x & 0xFFFF) + (y & 0xFFFF);
+		var msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+		return (msw << 16) | (lsw & 0xFFFF);
+	}
+ 
+	function S (X, n) { return ( X >>> n ) | (X << (32 - n)); }
+	function R (X, n) { return ( X >>> n ); }
+	function Ch(x, y, z) { return ((x & y) ^ ((~x) & z)); }
+	function Maj(x, y, z) { return ((x & y) ^ (x & z) ^ (y & z)); }
+	function Sigma0256(x) { return (S(x, 2) ^ S(x, 13) ^ S(x, 22)); }
+	function Sigma1256(x) { return (S(x, 6) ^ S(x, 11) ^ S(x, 25)); }
+	function Gamma0256(x) { return (S(x, 7) ^ S(x, 18) ^ R(x, 3)); }
+	function Gamma1256(x) { return (S(x, 17) ^ S(x, 19) ^ R(x, 10)); }
+
+	function binb2hex (binarray) {
+		var hex_tab = hexcase ? "0123456789ABCDEF" : "0123456789abcdef";
+		var str = "";
+		for(var i = 0; i < binarray.length * 4; i++) {
+			str += hex_tab.charAt((binarray[i>>2] >> ((3 - i%4)*8+4)) & 0xF) +
+			hex_tab.charAt((binarray[i>>2] >> ((3 - i%4)*8  )) & 0xF);
+		}
+		return str;
+	}
+ 
+	function core_sha256 (m, l) {
+		var K = new Array(0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5, 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5, 0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3, 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174, 0xE49B69C1, 0xEFBE4786, 0xFC19DC6, 0x240CA1CC, 0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA, 0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7, 0xC6E00BF3, 0xD5A79147, 0x6CA6351, 0x14292967, 0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13, 0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85, 0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3, 0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070, 0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5, 0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3, 0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208, 0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2);
+		var HASH = new Array(0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19);
+		var W = new Array(64);
+		var a, b, c, d, e, f, g, h, i, j;
+		var T1, T2;
+ 
+		m[l >> 5] |= 0x80 << (24 - l % 32);
+		m[((l + 64 >> 9) << 4) + 15] = l;
+ 
+ 		console.log("length", m.length);
+		for ( var i = 0; i<m.length; i+=16 ) {
+			a = HASH[0];
+			b = HASH[1];
+			c = HASH[2];
+			d = HASH[3];
+			e = HASH[4];
+			f = HASH[5];
+			g = HASH[6];
+			h = HASH[7];
+ 
+			for ( var j = 0; j<64; j++) {
+				if (j < 16) W[j] = m[j + i];
+				else W[j] = safe_add(safe_add(safe_add(Gamma1256(W[j - 2]), W[j - 7]), Gamma0256(W[j - 15])), W[j - 16]);
+ 
+				T1 = safe_add(safe_add(safe_add(safe_add(h, Sigma1256(e)), Ch(e, f, g)), K[j]), W[j]);
+				T2 = safe_add(Sigma0256(a), Maj(a, b, c));
+ 
+				h = g;
+				g = f;
+				f = e;
+				e = safe_add(d, T1);
+				d = c;
+				c = b;
+				b = a;
+				a = safe_add(T1, T2);
+			}
+ 
+			HASH[0] = safe_add(a, HASH[0]);
+			HASH[1] = safe_add(b, HASH[1]);
+			HASH[2] = safe_add(c, HASH[2]);
+			HASH[3] = safe_add(d, HASH[3]);
+			HASH[4] = safe_add(e, HASH[4]);
+			HASH[5] = safe_add(f, HASH[5]);
+			HASH[6] = safe_add(g, HASH[6]);
+			HASH[7] = safe_add(h, HASH[7]);
+
+			console.log("current digest:"+
+				binb2hex([HASH[0]]),
+				binb2hex([HASH[1]]),
+				binb2hex([HASH[2]]),
+				binb2hex([HASH[3]]),
+				binb2hex([HASH[4]]),
+				binb2hex([HASH[5]]),
+				binb2hex([HASH[6]]),
+				binb2hex([HASH[7]])
+			)
+		}
+		return HASH;
+	}
+ 
+	function str2binb (str) {
+		var bin = Array();
+		var mask = (1 << chrsz) - 1;
+		for(var i = 0; i < str.length * chrsz; i += chrsz) {
+			bin[i>>5] |= (str.charCodeAt(i / chrsz) & mask) << (24 - i%32);
+		}
+		return bin;
+	}
+ 
+	function Utf8Encode(string) {
+		string = string.replace(/\r\n/g,"\n");
+		var utftext = "";
+ 
+		for (var n = 0; n < string.length; n++) {
+ 
+			var c = string.charCodeAt(n);
+ 
+			if (c < 128) {
+				utftext += String.fromCharCode(c);
+			}
+			else if((c > 127) && (c < 2048)) {
+				utftext += String.fromCharCode((c >> 6) | 192);
+				utftext += String.fromCharCode((c & 63) | 128);
+			}
+			else {
+				utftext += String.fromCharCode((c >> 12) | 224);
+				utftext += String.fromCharCode(((c >> 6) & 63) | 128);
+				utftext += String.fromCharCode((c & 63) | 128);
+			}
+ 
+		}
+ 
+		return utftext;
+	}
+  
+  	console.log("pre length", s.length)
+	s = Utf8Encode(s);
+	return binb2hex(core_sha256(str2binb(s), s.length * chrsz)); 
+}
+
+
+var h = SHA256("POST\nsqs.ap-northeast-1.amazonaws.com\n/\nAWSAccessKeyId=AKIAI3AZWYC2NG6LU2EQ&Action=SendMessage&MessageBody=%7B%22email_id%22%3A2%2C%22contact_id%22%3A%221-xxxxx%40hotmail.es%22%2C%22bulk_id%22%3A1%2C%22email_version_id%22%3A14%2C%22client_id%22%3A1%7D&QueueUrl=http%3A%2F%2Fsqs.ap-northeast-1.amazonaws.com%2F871570535967%2FtestQueue&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T20%3A21%3A59%2B0900&Version=2012-11-05");
+console.log(h)

--- a/test/deps/sha2.lua
+++ b/test/deps/sha2.lua
@@ -1,0 +1,39 @@
+local sha2 = require 'lua-aws.deps.sha2'
+local vectors = {
+	[""] 							= "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855", 
+	["a"] 							= "CA978112CA1BBDCAFAC231B39A23DC4DA786EFF8147C4E72B9807785AFEE48BB", 
+	["abc"]							= "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD", 
+	["message digest"]				= "F7846F55CF23E14EEBEAB5B4E1550CAD5B509E3348FBC4EFA3A1413D393CB650",
+	["abcdefghijklmnopqrstuvwxyz"] 	= "71C480DF93D6AE2F1EFAD1447C66C9525E316218CF51FC8D9ED832F2DAF18B73",
+	["abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"]
+									= "248D6A61D20638B8E5C026930C3E6039A33CE45964FF2167F6ECEDD419DB06C1",
+	["A...Za...z0...9"]				= "E1904B6EFF23EB8D0D251254C8E71D9E3B3C6822A1C3F64427E9CE09933985EA", 
+		-- https://www.cosic.esat.kuleuven.be/nessie/testvectors/hash/sha/Sha-2-256.unverified.test-vectors says digest is
+		-- "DB4BFCBD4DA0CD85A60C3C37D3FBD8805C77F15FC6B1FDFE614EE0A7C8FDB4C0", but various implementation says digest is above.
+	[("1234567890"):rep(8)]			= "F371BC4A311F2B009EEF952DD83CA80E2B60026C8E935592D0F9C308453C813E",
+	[("a"):rep(1000 * 1000)]		= "CDC76E5C9914FB9281A1C7E284D73E67F1809A48A497200E046D39CCC7112CD0",
+}
+
+--[[
+local unmatches = {}
+for message, hash in pairs(vectors) do
+	local tag = message:sub(1,16)
+	if #message > #tag then
+		tag = (tag .. "...")
+	end
+	local h = sha2.hash256(message):upper()
+	if h ~= hash then
+		table.insert(unmatches, {tag, h, hash})
+	end
+end
+if #unmatches > 0 then
+	for _,um in ipairs(unmatches) do
+		print("unmatch ["..um[1].."] hash=["..um[2].."] should be ["..um[3].."]")
+	end
+	assert(false)
+end
+]]
+
+
+local h = sha2.hash256("POST\nsqs.ap-northeast-1.amazonaws.com\n/\nAWSAccessKeyId=AKIAI3AZWYC2NG6LU2EQ&Action=SendMessage&MessageBody=%7B%22email_id%22%3A2%2C%22contact_id%22%3A%221-xxxxx%40hotmail.es%22%2C%22bulk_id%22%3A1%2C%22email_version_id%22%3A14%2C%22client_id%22%3A1%7D&QueueUrl=http%3A%2F%2Fsqs.ap-northeast-1.amazonaws.com%2F871570535967%2FtestQueue&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T20%3A21%3A59%2B0900&Version=2012-11-05");
+assert(h == "570e036eefb1d926c544dcdc2ae37b23a785f1254d1797b5f208cae388369992", "wrong hash:"..h)

--- a/test/signer/v2.lua
+++ b/test/signer/v2.lua
@@ -37,3 +37,28 @@ signer:sign({
 -- TODO : can we provide universal test??? now its only for *ME*
 print('params:', params.Signature, util.unescape("hchgVw%2B5D5vwSSCgMVsOt5ycJjb6bDOpNmCe4EpLavo%3D"))
 assert(params.Signature == util.unescape("hchgVw%2B5D5vwSSCgMVsOt5ycJjb6bDOpNmCe4EpLavo%3D"))
+
+
+params.Signature = nil
+params.MessageBody = [[{"email_id":2,"contact_id":"1-xxxxx@hotmail.es","bulk_id":1,"email_version_id":14,"client_id":1}]]
+
+signer:sign({
+	method = "POST",
+	headers = {},
+	host = "sqs.ap-northeast-1.amazonaws.com",
+	path = "/",
+	params = params,
+}, {
+	accessKeyId = os.getenv('AWS_ACCESS_KEY'),
+	secretAccessKey = os.getenv('AWS_SECRET_KEY'),	
+}, "2014-10-16T20:21:59+0900")
+
+print('params2:', params.Signature, util.unescape("VwPl0RHrLKPjTi64XgqDMqT9cVPoJ72MQFS7Q8AgPBc%3D"))
+assert(params.Signature == util.unescape("VwPl0RHrLKPjTi64XgqDMqT9cVPoJ72MQFS7Q8AgPBc%3D"))
+
+
+
+
+
+
+

--- a/test/sqs.lua
+++ b/test/sqs.lua
@@ -23,7 +23,7 @@ local QueueUrl = res.value.CreateQueueResponse.value.CreateQueueResult.value.Que
 print("QueueUrl:", QueueUrl)
 local params = {
 	QueueUrl = QueueUrl,
-	MessageBody = "testing"
+	MessageBody = [[{"email_id":2,"contact_id":"1-xxxxx@hotmail.es","bulk_id":1,"email_version_id":14,"client_id":1}]]
 }
 res = aws.SQS:api_by_version('2012-11-05'):sendMessage(params)
 dump_res('message', res)


### PR DESCRIPTION
refs #4 

lua-aws sha2 routine (taken from http://lua-users.org/wiki/SecureHashAlgorithm) seems to have a problem in pre-processing when message length is 55 (mod 64) in bytes. 

sha2 pre-processing is defined as below. (from definition of http://www.wikiwand.com/en/SHA-2 )

```
Pre-processing:
append the bit '1' to the message
append k bits '0', where k is the minimum number >= 0 such that the resulting message
    length (modulo 512 in bits) is 448.
append length of message (without the '1' bit or padding), in bits, as 64-bit big-endian integer
    (this will make the entire post-processed length a multiple of 512 bits)
```

and here is implementation of pre-processing in [above page](http://lua-users.org/wiki/SecureHashAlgorithm)

``` lua
local function preproc (msg, len)
  local extra = 64 - ((len + 1 + 8) % 64)
  len = num2s(8 * len, 8)    -- original len in bits, coded
  msg = msg .. "\128" .. string.rep("\0", extra) .. len
```

if message length is 55 (mod 64), appending the bit '1' to the message ( appending "\128" in the code )
makes total message length 56 (mod 64), so no more zeroes need to be appended. but actually variable 'extra' become 64 in this case. so unnecessary 512 bits '0' appended to message, which causes wrongly calculated sha2 hash value.

for example, following payload

```
POST\nsqs.ap-northeast-1.amazonaws.com\n/\nAWSAccessKeyId=AKIAI3AZWYC2NG6LU2EQ&Action=SendMessage&MessageBody=%7B%22email_id%22%3A2%2C%22contact_id%22%3A%221-xxxxx%40hotmail.es%22%2C%22bulk_id%22%3A1%2C%22email_version_id%22%3A14%2C%22client_id%22%3A1%7D&QueueUrl=http%3A%2F%2Fsqs.ap-northeast-1.amazonaws.com%2F871570535967%2FtestQueue&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T20%3A21%3A59%2B0900&Version=2012-11-05
```

should be hashed to 

```
570e036eefb1d926c544dcdc2ae37b23a785f1254d1797b5f208cae388369992
```

but actually hashed to

```
4952c897492c10a4b2e8c7cf9f80285ac4b0dfdd8bd6219799e4780be73e2725
```

by old implementation.
