### PR TITLE
alternate way to adding rockspec

### DIFF
--- a/lua-aws-0.1-1.rockspec
+++ b/lua-aws-0.1-1.rockspec
@@ -1,0 +1,61 @@
+package = "lua-aws"
+version = "0.1-1"
+source = {
+  url = "https://github.com/umegaya/lua-aws.git"
+}
+description = {
+  summary = "Pure-lua implementation of AWS REST APIs",
+  detailed = [[
+    It heavily inspired by aws-sdk-js, 
+    which main good point is define all AWS sevices by JS data structure. 
+    and library read these data and building API code on the fly
+  ]],
+  homepage = "https://github.com/umegaya/lua-aws",
+  license = " Apache License 2.0"
+}
+dependencies = {
+  "lua ~> 5.1"
+}
+build = {
+  type = "builtin",
+  copy_directories = {
+    "lua-aws/services/definitions"
+  },
+  modules = {
+    ["lua-aws"] = "lua-aws/init.lua",
+    ["lua-aws.class"] = "lua-aws/class.lua",
+    ["lua-aws.deps.dkjson"] = "lua-aws/deps/dkjson.lua",
+    ["lua-aws.deps.sha1"] = "lua-aws/deps/sha1.lua",
+    ["lua-aws.deps.slaxdom"] = "lua-aws/deps/slaxdom.lua",
+    ["lua-aws.deps.slaxml"] = "lua-aws/deps/slaxml.lua",
+    ["lua-aws.deps.sha2"] = "lua-aws/deps/sha2.lua",
+    ["lua-aws.request"] = "lua-aws/request.lua",
+    ["lua-aws.requests.rest"] = "lua-aws/requests/rest.lua",
+    ["lua-aws.requests.rest_json"] = "lua-aws/requests/rest_json.lua",
+    ["lua-aws.requests.rest_xml"] = "lua-aws/requests/rest_xml.lua",
+    ["lua-aws.requests.base"] = "lua-aws/requests/base.lua",
+    ["lua-aws.requests.endpoint"] = "lua-aws/requests/endpoint.lua",
+    ["lua-aws.requests.json"] = "lua-aws/requests/json.lua",
+    ["lua-aws.requests.query"] = "lua-aws/requests/query.lua",
+    ["lua-aws.requests.query_string_serializer"] = "lua-aws/requests/query_string_serializer.lua",
+    ["lua-aws.services.dynamodb"] = "lua-aws/services/dynamodb.lua",
+    ["lua-aws.services.ec2"] = "lua-aws/services/ec2.lua",
+    ["lua-aws.services.sqs"] = "lua-aws/services/sqs.lua",
+    ["lua-aws.services.base"] = "lua-aws/services/base.lua",
+    ["lua-aws.services.kinesis"] = "lua-aws/services/kinesis.lua",
+    ["lua-aws.services.sns"] = "lua-aws/services/sns.lua",
+    ["lua-aws.signer"] = "lua-aws/signer.lua",
+    ["lua-aws.signers.base"] = "lua-aws/signers/base.lua",
+    ["lua-aws.signers.cloudfront"] = "lua-aws/signers/cloudfront.lua",
+    ["lua-aws.signers.s3"] = "lua-aws/signers/s3.lua",
+    ["lua-aws.signers.v3"] = "lua-aws/signers/v3.lua",
+    ["lua-aws.signers.v3https"] = "lua-aws/signers/v3https.lua",
+    ["lua-aws.signers.v2"] = "lua-aws/signers/v2.lua",
+    ["lua-aws.signers.v4"] = "lua-aws/signers/v4.lua",
+    ["lua-aws.api"] = "lua-aws/api.lua",
+    ["lua-aws.core"] = "lua-aws/core.lua",
+    ["lua-aws.engines.curl"] = "lua-aws/engines/curl.lua",
+    ["lua-aws.engines.luasocket"] = "lua-aws/engines/luasocket.lua",
+    ["lua-aws.util"] = "lua-aws/util.lua"
+  }
+}

--- a/lua-aws-0.1-1.rockspec
+++ b/lua-aws-0.1-1.rockspec
@@ -1,7 +1,7 @@
 package = "lua-aws"
 version = "0.1-1"
 source = {
-  url = "https://github.com/umegaya/lua-aws.git"
+  url = "git://github.com/umegaya/lua-aws.git"
 }
 description = {
   summary = "Pure-lua implementation of AWS REST APIs",
@@ -17,45 +17,6 @@ dependencies = {
   "lua ~> 5.1"
 }
 build = {
-  type = "builtin",
-  copy_directories = {
-    "lua-aws/services/definitions"
-  },
-  modules = {
-    ["lua-aws"] = "lua-aws/init.lua",
-    ["lua-aws.class"] = "lua-aws/class.lua",
-    ["lua-aws.deps.dkjson"] = "lua-aws/deps/dkjson.lua",
-    ["lua-aws.deps.sha1"] = "lua-aws/deps/sha1.lua",
-    ["lua-aws.deps.slaxdom"] = "lua-aws/deps/slaxdom.lua",
-    ["lua-aws.deps.slaxml"] = "lua-aws/deps/slaxml.lua",
-    ["lua-aws.deps.sha2"] = "lua-aws/deps/sha2.lua",
-    ["lua-aws.request"] = "lua-aws/request.lua",
-    ["lua-aws.requests.rest"] = "lua-aws/requests/rest.lua",
-    ["lua-aws.requests.rest_json"] = "lua-aws/requests/rest_json.lua",
-    ["lua-aws.requests.rest_xml"] = "lua-aws/requests/rest_xml.lua",
-    ["lua-aws.requests.base"] = "lua-aws/requests/base.lua",
-    ["lua-aws.requests.endpoint"] = "lua-aws/requests/endpoint.lua",
-    ["lua-aws.requests.json"] = "lua-aws/requests/json.lua",
-    ["lua-aws.requests.query"] = "lua-aws/requests/query.lua",
-    ["lua-aws.requests.query_string_serializer"] = "lua-aws/requests/query_string_serializer.lua",
-    ["lua-aws.services.dynamodb"] = "lua-aws/services/dynamodb.lua",
-    ["lua-aws.services.ec2"] = "lua-aws/services/ec2.lua",
-    ["lua-aws.services.sqs"] = "lua-aws/services/sqs.lua",
-    ["lua-aws.services.base"] = "lua-aws/services/base.lua",
-    ["lua-aws.services.kinesis"] = "lua-aws/services/kinesis.lua",
-    ["lua-aws.services.sns"] = "lua-aws/services/sns.lua",
-    ["lua-aws.signer"] = "lua-aws/signer.lua",
-    ["lua-aws.signers.base"] = "lua-aws/signers/base.lua",
-    ["lua-aws.signers.cloudfront"] = "lua-aws/signers/cloudfront.lua",
-    ["lua-aws.signers.s3"] = "lua-aws/signers/s3.lua",
-    ["lua-aws.signers.v3"] = "lua-aws/signers/v3.lua",
-    ["lua-aws.signers.v3https"] = "lua-aws/signers/v3https.lua",
-    ["lua-aws.signers.v2"] = "lua-aws/signers/v2.lua",
-    ["lua-aws.signers.v4"] = "lua-aws/signers/v4.lua",
-    ["lua-aws.api"] = "lua-aws/api.lua",
-    ["lua-aws.core"] = "lua-aws/core.lua",
-    ["lua-aws.engines.curl"] = "lua-aws/engines/curl.lua",
-    ["lua-aws.engines.luasocket"] = "lua-aws/engines/luasocket.lua",
-    ["lua-aws.util"] = "lua-aws/util.lua"
-  }
+  type = "command",
+  install_command = "cp -r lua-aws /usr/local/share/lua/5.1/lua-aws",
 }

--- a/lua-aws/services/base.lua
+++ b/lua-aws/services/base.lua
@@ -15,7 +15,7 @@ return class.AWS_Service {
 		local latest
 		local apis = {}
 		local service_name = self._service_name:lower()
-		util.dir((util.services_path()..'/definitions/%s*'):format(service_name)):each(function (path)
+		util.dir((util.script_path()..'/definitions/%s*'):format(service_name)):each(function (path)
 			--print('defintion file:', path)
 			local version
 			path:gsub('[^%-]*%-([%w%-]*)%.js', function (s)

--- a/lua-aws/services/base.lua
+++ b/lua-aws/services/base.lua
@@ -15,7 +15,7 @@ return class.AWS_Service {
 		local latest
 		local apis = {}
 		local service_name = self._service_name:lower()
-		util.dir((util.script_path()..'/definitions/%s*'):format(service_name)):each(function (path)
+		util.dir((util.services_path()..'/definitions/%s*'):format(service_name)):each(function (path)
 			--print('defintion file:', path)
 			local version
 			path:gsub('[^%-]*%-([%w%-]*)%.js', function (s)

--- a/lua-aws/util.lua
+++ b/lua-aws/util.lua
@@ -460,9 +460,7 @@ _M.date = {
 
 function _M.script_path()
    local str = debug.getinfo(2, "S").source:sub(2)
-   local res = str:match("(.*/)")
-   print(res)
-   return res
+   return str:match("(.*/)")
 end
 
 function _M.services_path()

--- a/lua-aws/util.lua
+++ b/lua-aws/util.lua
@@ -458,20 +458,15 @@ _M.date = {
 	end,
 }
 
-function _M.p(i)
-  local _obj_0 = require("moon")
-  p = _obj_0.p
-  return p(i)
-end
-
-function _M.die(str)
-  print(str)
-  return os.exit()
-end
-
 function _M.script_path()
    local str = debug.getinfo(2, "S").source:sub(2)
-   return str:match("(.*/)")
+   local res = str:match("(.*/)")
+   print(res)
+   return res
+end
+
+function _M.services_path()
+   return "/usr/lib/luarocks/rocks/lua-aws/0.1-1/lua-aws/services"
 end
 
 return _M


### PR DESCRIPTION
refs #11
I check PR from https://github.com/CriztianiX/lua-aws, there is two points to discuss.
the purpose of this PR is describe my opinion about these points with working implementation.

1. we should treat dkjson as external dependency?
 - if we obey the standard way of luarocks, dkjson should be treat as external dependency because it has entry in luarocks. 
 - but it means that potentially lua-aws have to support multiple version of dkjson, also any kind of project-specific modification to dkjson is not allowed. 
 - so I prefer to maintain dkjson's version by ourselves for better flexibility and maintainability. 

2. how we provide json AWS REST API definition files?
 - in AWS_Service.build_api, util.script_path change to util.service_path which returns static path string by changes made in #11. 
 - if I understand correctly, this is because there is no standard way to install lua-aws/services/definitions/*.json to /usr/local/share/lua/5.1/lua-aws/services/definitions/
 - but luarocks "command" build backend seems to achieve it by just copying entire files under lua-aws to rocks directory, through it breaks some portability (especially windows). 
 - if so, I want to revert the change. because with this change, we force user to use lua-aws with luarocks installation. I also use lua-aws without installation (part of luact)

@CriztianiX how do you think? 