### PR TITLE
Empty files, fix list serialization

### DIFF
--- a/lua-aws/requests/query_string_serializer.lua
+++ b/lua-aws/requests/query_string_serializer.lua
@@ -33,14 +33,18 @@ return class.AWS_RequestSerializer {
 	end,
 
 	serialize_list = function (self, name, list, rules, fn)
-		local memberRules = rules.members or {}
+		local memberRules = rules.member or {}
 		for n,v in ipairs(list) do
-			local suffix = ('.' .. tostring(n + 1))
+			local suffix = ('.' .. tostring(n))
 			if rules.flattened then
-				if memberRules.name then
+				if memberRules.locationName then
 					local parts = util.split(name, '.')
 					table.remove(parts, 1)
-					table.insert(parts, memberRules.name)
+					-- There may have been an empty entry on the end, remove it
+					if #parts > 0 and parts[#parts] == "" then
+						table.remove(parts, #parts)
+					end
+					table.insert(parts, memberRules.locationName)
 					name = util.join(parts, '.')
 				end
 			else

--- a/lua-aws/requests/rest.lua
+++ b/lua-aws/requests/rest.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/requests/rest_json.lua
+++ b/lua-aws/requests/rest_json.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/requests/rest_xml.lua
+++ b/lua-aws/requests/rest_xml.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/signers/cloudfront.lua
+++ b/lua-aws/signers/cloudfront.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/signers/s3.lua
+++ b/lua-aws/signers/s3.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/signers/v3.lua
+++ b/lua-aws/signers/v3.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/signers/v3https.lua
+++ b/lua-aws/signers/v3https.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank


### PR DESCRIPTION
Mark empty files as being specifically empty by design.

When serializing queries, remember that arrays in Lua start at 1,
so no need to add 1 to the indices.

The member rules are in rules.member, not rules.members.

If a member has a different name, it's called locationName, not
name.

Finally, the split routine sometimes leaves a blank entry on the
end.  Apparently some consumers of the library expect that, but when
serializing a list with a custom name it doesn't work right, so look
for that and remove it.

This makes the sendMessageBatch and deleteMessageBatch routines work
properly for SQS.