### PR TITLE
Mark empty files as being specifically empty by design

### DIFF
--- a/lua-aws/requests/rest_json.lua
+++ b/lua-aws/requests/rest_json.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/shape/builder/json.lua
+++ b/lua-aws/shape/builder/json.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/shape/translator/json.lua
+++ b/lua-aws/shape/translator/json.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/signers/cloudfront.lua
+++ b/lua-aws/signers/cloudfront.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/signers/v3.lua
+++ b/lua-aws/signers/v3.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank

--- a/lua-aws/signers/v3https.lua
+++ b/lua-aws/signers/v3https.lua
@@ -1,0 +1,1 @@
+-- Intentionally blank


### PR DESCRIPTION
Some of the files will fail with lualint, because they are empty. Add a comment to each empty file, that it is intentionally empty.

This extends a similar change in @ahpeterson 's fork of lua-aws.