### PR TITLE
unescape &***; in xml data

### DIFF
--- a/lua-aws/util.lua
+++ b/lua-aws/util.lua
@@ -19,6 +19,20 @@ _M.xml = (function ()
 		end)
 		return arg
 	end
+	local unescape_map = {
+		amp = "&",
+		lt = "<",
+		gt = ">",
+		quot = "\"",
+		apos = "'",
+	}
+	local function unescape(text)
+		return text:gsub("&([a-z]+);", function (s)
+			return unescape_map[s] or ("&"..s..";")
+		end)
+	end
+	local tmp = "&amp;&lt;&gt;&quot;&apos;&invalid;"
+	assert(unescape(tmp) == "&<>\"'&invalid;")
 	return {
 		encode = function (data)
 			return xml_build:dom(data)
@@ -38,7 +52,7 @@ _M.xml = (function ()
 					if text:find('<?xml') then
 						top.header = text
 					else
-						top.value = text
+						top.value = unescape(text)
 					end
 				end
 				if empty == "/" then  -- empty element tag

--- a/test/sqs.lua
+++ b/test/sqs.lua
@@ -14,13 +14,22 @@ dump_res('create', r)
 
 local QueueUrl = r.value.CreateQueueResponse.value.CreateQueueResult.value.QueueUrl.value
 print("QueueUrl:", QueueUrl)
+local jsonmsg = [[{"email_id":2,"contact_id":"1-xxxxx@hotmail.es","bulk_id":1,"email_version_id":14,"client_id":1}]]
 local params = {
 	QueueUrl = QueueUrl,
-	MessageBody = [[{"email_id":2,"contact_id":"1-xxxxx@hotmail.es","bulk_id":1,"email_version_id":14,"client_id":1}]]
+	MessageBody = jsonmsg
 }
 ok,r = aws.SQS:api_by_version('2012-11-05'):sendMessage(params)
 assert(ok, r)
-dump_res('message', r)
+dump_res('send', r)
+
+ok,r = aws.SQS:api_by_version('2012-11-05'):receiveMessage({
+	QueueUrl = QueueUrl,
+	Foo = Bar, -- un-ruled parameter test
+})
+assert(ok, r)
+dump_res('recv1', r)
+assert(r.value.ReceiveMessageResponse.value.ReceiveMessageResult.value.Message.value.Body.value == jsonmsg)
 
 local params = {
 	QueueUrl = QueueUrl,
@@ -43,7 +52,7 @@ local params = {
 }
 ok,r = aws.SQS:api_by_version('2012-11-05'):sendMessageBatch(params)
 assert(ok, r)
-dump_res('send', r)
+dump_res('sendbatch', r)
 
 
 ok,r = aws.SQS:api_by_version('2012-11-05'):receiveMessage({
@@ -51,7 +60,7 @@ ok,r = aws.SQS:api_by_version('2012-11-05'):receiveMessage({
 	Foo = Bar, -- un-ruled parameter test
 })
 assert(ok, r)
-dump_res('recv', r)
+dump_res('recv2', r)
 
 
 ok,r = aws.SQS:api_by_version('2012-11-05'):deleteQueue({


### PR DESCRIPTION
refs #30 
xml response seems to quote html special chars (>,<,&,",') in its payload, 
which should be unescaped.