### PR TITLE
can specify role instead of credentials @ AWS instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ now there is no rockspec so please copy them directory like /usr/local/share/lua
   - as of lua 5.3, built-in bit operator like ```&``` is introduced. as a result, no standard bit library is shipped with lua itself, which we used in lua-aws/deps/sha2.lua. so if you want to use lua-aws in such environment, you manually install a module like below which gives compatibility to old bit module. 
     - [bit](https://github.com/aryajur/bit.git) Suggested module to work across Lua versions 5.2 and 5.3
 
+
 ## Usage
 
 see test/ec2.lua

--- a/lua-aws/core.lua
+++ b/lua-aws/core.lua
@@ -82,12 +82,12 @@ local AWS = class.AWS {
 				protocol = 'http',
 				method = 'GET'
 			})
-			local obj = self._json_engine:decode(resp.body)
-			config.accessKeyId = obj.accessKeyId
-			config.secretAccessKey = obj.secretAccessKey
-		else
-			assert(config.accessKeyId and config.secretAccessKey)
+			local obj = self._json_engine.decode(resp.body)
+			config.accessKeyId = obj.AccessKeyId
+			config.secretAccessKey = obj.SecretAccessKey
+			config.sessionToken = obj.Token
 		end
+		assert(config.accessKeyId and config.secretAccessKey)
 		return config
 	end,
 	init_engines = function (self, preferred)

--- a/lua-aws/core.lua
+++ b/lua-aws/core.lua
@@ -6,9 +6,7 @@ assert(available_engines)
 local AWS = class.AWS {
 	VERSION = 'v0.1.0',
 	initialize = function (self, config, http_engine)
-		assert(config and config.accessKeyId and config.secretAccessKey)
-		self._config = self:verify_and_fill_config(config)
-
+		assert(config)
 		if http_engine then -- backward conpatibility
 			if not config.preferred_engines then
 				config.preferred_engines = {}
@@ -19,6 +17,8 @@ local AWS = class.AWS {
 		self._http_engine = engines.http
 		self._json_engine = engines.json
 		self._fs_engine = engines.fs
+		-- check or retrieve credentials / force enable SSL for default
+		self._config = self:verify_and_fill_config(config)
 		--self._http_engine = http_engine or self:get_http_engine()
 		--> define service
 		self.DynamoDB = require('lua-aws.services.dynamodb').new(self)
@@ -70,6 +70,23 @@ local AWS = class.AWS {
 			config.sslEnabled = true
 		elseif not config.sslEnabled then
 			print('https disabled: its strongly recommended to use https instead of non-secure version')
+		end
+		if config.role then
+			-- get credential from role
+			assert(self._http_engine and self._json_engine) -- http/json should be already initialized
+			local resp = self:http_request({
+				path = ('/latest/meta-data/iam/security-credentials/' .. config.role),
+				headers = {},
+				host = '169.254.169.254',
+				port = 80,
+				protocol = 'http',
+				method = 'GET'
+			})
+			local obj = self._json_engine:decode(resp.body)
+			config.accessKeyId = obj.accessKeyId
+			config.secretAccessKey = obj.secretAccessKey
+		else
+			assert(config.accessKeyId and config.secretAccessKey)
 		end
 		return config
 	end,

--- a/test/iam_role.lua
+++ b/test/iam_role.lua
@@ -3,9 +3,15 @@ local util = require 'lua-aws.util'
 local AWS = require ('lua-aws.init')
 local dump_res = helper.dump_res
 
+if os.getenv('AWS_ACCESS_KEY') then
+	-- ignored in non-aws instance environment
+	return
+end
+
 local aws = AWS.new({
-	role = '',
+	role = 'aws_auto_cred_test',
 	sslEnabled = not helper.MOCK_HOST(),
+	region = 'ap-northeast-1',
 	endpoint = helper.MOCK_HOST(),
 })
 

--- a/test/iam_role.lua
+++ b/test/iam_role.lua
@@ -1,0 +1,19 @@
+local helper = require 'test.helper.util'
+local util = require 'lua-aws.util'
+local AWS = require ('lua-aws.init')
+local dump_res = helper.dump_res
+
+local aws = AWS.new({
+	role = '',
+	sslEnabled = not helper.MOCK_HOST(),
+	endpoint = helper.MOCK_HOST(),
+})
+
+local ok,r = aws.EC2:api():describeInstances()
+
+if ok then
+	assert(r.value.DescribeInstancesResponse.xarg.xmlns:match("http://ec2.amazonaws.com/doc"))
+else
+	assert(false, 'error:' .. r)
+end
+


### PR DESCRIPTION
refs #47 

### detail
at AWS instance, able to get credentials automatically by setting IAM role name which is set to the instance. 

see [test/iam_role.lua](https://github.com/umegaya/lua-aws/blob/umegaya/auto_cred/test/iam_role.lua) for usage. 

### consideration
if only one role for the instance, automatically use this? but this requires 2 round trips...