### PR TITLE
fix ec2 request serializer bug (wrongly ported from aws-sdk-js)

### DIFF
--- a/lua-aws/api.lua
+++ b/lua-aws/api.lua
@@ -52,6 +52,9 @@ return class.AWS_API {
 	json_version = function (self)
 		return self._defs.metadata.jsonVersion or "1.0"
 	end,
+	protocol = function (self)
+		return self._defs.metadata.protocol
+	end,
 	endpoint = function (self)
 		-- give 1st priority to manually configured endpoint
 		local config = self:config()

--- a/lua-aws/requests/query_string_serializer.lua
+++ b/lua-aws/requests/query_string_serializer.lua
@@ -38,9 +38,12 @@ return class.AWS_RequestSerializer {
 
 	serialize_list = function (self, name, list, rules, fn)
 		local memberRules = rules.member or {}
+		local ec2 = self._api:protocol() == 'ec2'
 		for n,v in ipairs(list) do
 			local suffix = ('.' .. tostring(n))
-			if rules.flattened then
+			if ec2 then
+				-- do nothing for ec2 protcol (borrow from aws-sdk-js)
+			elseif rules.flattened then
 				if memberRules.name then
 					local parts = util.split(name, '.')
 					table.remove(parts, 1)

--- a/test/athena.lua
+++ b/test/athena.lua
@@ -7,10 +7,14 @@ local aws = AWS.new({
 	endpoint = helper.MOCK_HOST(),
 })
 
-local ok,r = aws.Athena:api():listNamedQueries()
+if not helper.MOCK_HOST() then
+	-- 2018/08/07 iyatomi moto_server does not seem to support 
+	local ok,r = aws.Athena:api():listNamedQueries()
 
-if not ok then
-	helper.dump = true
-	helper.dump_res('athena', r)
-	assert(false, 'error:' .. r)
+	if not ok then
+		helper.dump = true
+		helper.dump_res('athena', r)
+		assert(false, 'error:' .. r)
+	end
+
 end

--- a/test/ec2.lua
+++ b/test/ec2.lua
@@ -21,7 +21,6 @@ helper.iterate_all_engines("ec2", function (preferred)
 	end
 end)
 
-
 -- old retval format error
 local aws = AWS.new({
 	accessKeyId = os.getenv('AWS_ACCESS_KEY'),
@@ -39,4 +38,36 @@ if not r.code then
 	assert(r.value.DescribeInstancesResponse.xarg.xmlns:match("http://ec2.amazonaws.com/doc"))
 else
 	assert(false, 'error:' .. err)
+end
+
+-- describeInstance test (only with mock mode)
+if helper.MOCK_HOST() then
+	local cr = aws.EC2:api():runInstances({
+		MinCount = 2, 
+		MaxCount = 2,
+	})
+	-- helper.dump = true
+	-- helper.dump_res('ec2 runInstances', cr)
+	local iid = cr.value.RunInstancesResponse.value.instancesSet.value.item[1].value.instanceId.value
+	local iid2 = cr.value.RunInstancesResponse.value.instancesSet.value.item[2].value.instanceId.value
+	-- print('instanceIds', iid, iid2)
+	local dr = aws.EC2:api():describeInstances({
+		InstanceIds = { iid }
+	})
+	local dri = dr.value.DescribeInstancesResponse.value.reservationSet.value.item.value.instancesSet.value.item
+	-- helper.dump_res('ec2 describeInstances', dr)
+	-- print('#dr', (#dri), dri.value.instanceId.value)
+	-- item should not be array (only single element returns)
+	assert((#dri) == 0)
+	assert(dri.value.instanceId.value == iid)
+
+	local dr2 = aws.EC2:api():describeInstances({
+		InstanceIds = { iid, iid2 }
+	})
+	local dri2 = dr2.value.DescribeInstancesResponse.value.reservationSet.value.item.value.instancesSet.value.item
+
+	assert((#dri2) == 2)
+	assert(dri2[1].value.instanceId.value == iid)
+	assert(dri2[2].value.instanceId.value == iid2)
+
 end

--- a/test/firehose.lua
+++ b/test/firehose.lua
@@ -7,10 +7,14 @@ local aws = AWS.new({
 	endpoint = helper.MOCK_HOST(),
 })
 
-local ok,r = aws.Firehose:api():listDeliveryStreams()
+if not helper.MOCK_HOST() then
+	-- 2018/08/07 iyatomi moto_server does not seem to support 
 
-if not ok then
-	helper.dump = true
-	helper.dump_res('athena', r)
-	assert(false, 'error:' .. r)
+	local ok,r = aws.Firehose:api():listDeliveryStreams()
+
+	if not ok then
+		helper.dump = true
+		helper.dump_res('athena', r)
+		assert(false, 'error:' .. r)
+	end
 end

--- a/test/tools/run.sh
+++ b/test/tools/run.sh
@@ -28,7 +28,8 @@ if [ ! -z $2 ]; then
 			echo "cannot get pid"
 			exit 1
 		fi
-		sleep 1
+		echo "running mock server at $PID"
+		sleep 2
 		# run test with using mock
 		$LUA $1 http://127.0.0.1:5000
 		RESULT=$?


### PR DESCRIPTION
refs #50 
I think I wrongly port query serializer for ec2 from aws-sdk-js (ignore https://github.com/aws/aws-sdk-js/blob/master/lib/query/query_param_serializer.js#L52)