### PR TITLE
Add Credentials class

### DIFF
--- a/lua-aws/class.lua
+++ b/lua-aws/class.lua
@@ -29,11 +29,7 @@ local class = (function ()
 			return nil
 		end
 		local __lookup = function(self, method)
-			local m = self.class[method]
-			if not m then	
-				error('no such method: ' .. method .. "\n" .. debug.traceback())
-			end
-			return m
+			return self.class[method]
 		end
 		local __conflict_detector = function (self)
 			return setmetatable({ __proxy = self }, {

--- a/lua-aws/core.lua
+++ b/lua-aws/core.lua
@@ -1,4 +1,5 @@
 local class = require('lua-aws.class')
+local Credentials = require('lua-aws.credentials')
 local util = require('lua-aws.util')
 local available_engines = require 'lua-aws.engines.available'
 assert(available_engines)
@@ -86,11 +87,16 @@ local AWS = class.AWS {
 				method = 'GET'
 			})
 			local obj = self._json_engine.decode(resp.body)
-			config.accessKeyId = obj.AccessKeyId
-			config.secretAccessKey = obj.SecretAccessKey
-			config.sessionToken = obj.Token
+			config.credentials = Credentials.new({
+				accessKeyId = obj.AccessKeyId,
+				secretAccessKey = obj.SecretAccessKey,
+				sessionToken = obj.Token,
+			})
 		end
-		assert(config.accessKeyId and config.secretAccessKey)
+		if config.accessKeyId and config.secretAccessKey then
+			config.credentials = Credentials.new(config)
+		end
+		assert(config.credentials)
 		return config
 	end,
 	init_engines = function (self, preferred)

--- a/lua-aws/core.lua
+++ b/lua-aws/core.lua
@@ -92,8 +92,7 @@ local AWS = class.AWS {
 				secretAccessKey = obj.SecretAccessKey,
 				sessionToken = obj.Token,
 			})
-		end
-		if config.accessKeyId and config.secretAccessKey then
+		elseif config.accessKeyId and config.secretAccessKey then
 			config.credentials = Credentials.new(config)
 		end
 		assert(config.credentials)

--- a/lua-aws/credentials.lua
+++ b/lua-aws/credentials.lua
@@ -1,0 +1,40 @@
+local class = require ('lua-aws.class')
+
+return class.AWS_Credentials {
+	initialize = function(self, options)
+		self.expired = false
+		self.expireTime = nil
+		self.accessKeyId = options.accessKeyId
+		self.secretAccessKey = options.secretAccessKey
+		self.sessionToken = options.sessionToken
+	end,
+
+	expiryWindow = 15,
+
+	needsRefresh = function(self)
+		if not self.expireTime then
+			return self.expired or (not self.accessKeyId) or (not self.secretAccessKey)
+		end
+
+		local currentTime = os.time()
+		local adjustedTime = currentTime + self.expiryWindow
+		return adjustedTime > self.expireTime
+	end,
+
+	get = function(self)
+		if self:needsRefresh() then
+			local ok, err = self:refresh()
+			if ok then
+				self.expired = false
+			end
+			return ok, err
+		else
+			return true
+		end
+	end,
+
+	refresh = function(self)
+		self.expired = false
+		return true
+	end,
+}

--- a/lua-aws/requests/base.lua
+++ b/lua-aws/requests/base.lua
@@ -18,13 +18,16 @@ return class.AWS_Request {
 	send = function (self, params, resp)
 		assert(params)
 		local req = self:base_build_request()
-                local params_for_sign
+		local params_for_sign
 		req, params_for_sign = self:build_request(req, params)
-		self:validate(req)
+		local ok, err = self:validate(req)
+		if not ok then
+			return false, err
+		end
 		local ts = self._api:signature_timestamp()
 		-- if params_for_sign is specified, use it as signature parameter.
-		req.params = params_for_sign or params 
-		self._signer:sign(req, self._api:config(), ts)
+		req.params = params_for_sign or params
+		self._signer:sign(req, self._api:config().credentials, ts)
 		req.params = nil
 		resp = self._api:http_request(req, resp)
 		-- aws sometimes returns 2xx codes other than 200. (eg. 204 No Content)
@@ -60,12 +63,20 @@ return class.AWS_Request {
 		end
 		return self._output
 	end,
+	validate_credentials = function (self, req)
+		local config = self._api:config()
+		return config.credentials:get()
+	end,
 	validate_region = function (self, req)
 	end,
 	validate_parameter = function (self, req)
 		-- local input = self:input_format()
 	end,
 	validate = function (self, req)
+		local ok, err = self:validate_credentials(req)
+		if not ok then
+			return false, err
+		end
 		self:validate_region(req)
 		self:validate_parameter(req)
 		return true

--- a/lua-aws/requests/base.lua
+++ b/lua-aws/requests/base.lua
@@ -65,7 +65,15 @@ return class.AWS_Request {
 	end,
 	validate_credentials = function (self, req)
 		local config = self._api:config()
-		return config.credentials:get()
+		local ok, err = config.credentials:get()
+		if not ok then
+			err = {
+				code = 'CredentialsError',
+				message = 'Missing credentials in config',
+				originalError = err,
+			}
+		end
+		return ok, err
 	end,
 	validate_region = function (self, req)
 	end,

--- a/test/modules/credentials.lua
+++ b/test/modules/credentials.lua
@@ -1,0 +1,11 @@
+local Credentials = require ('lua-aws.credentials')
+
+local credentials = Credentials.new({
+  accessKeyId = os.getenv('AWS_ACCESS_KEY'),
+  secretAccessKey = os.getenv('AWS_SECRET_KEY'),
+})
+
+assert(credentials:accessKeyId)
+assert(credentials:secretAccessKey)
+assert(not credentials:needsRefresh())
+assert(credentials:get())

--- a/test/modules/credentials.lua
+++ b/test/modules/credentials.lua
@@ -5,7 +5,7 @@ local credentials = Credentials.new({
   secretAccessKey = os.getenv('AWS_SECRET_KEY'),
 })
 
-assert(credentials:accessKeyId)
-assert(credentials:secretAccessKey)
+assert(credentials.accessKeyId)
+assert(credentials.secretAccessKey)
 assert(not credentials:needsRefresh())
 assert(credentials:get())


### PR DESCRIPTION
Added `lua-aws.credentials` and enabled to pass it as an option.

```lua
local Credentials = require('lua-aws.credentials')
local credentials = Credentials.new({
  accessKeyId = accessKeyId,
  secretAccessKey = secretAccessKey,
})
local aws = AWS.new({
  credentials = credentials,
  ...
})
```